### PR TITLE
changing capitalization in R

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RClientCodegen.java
@@ -406,7 +406,7 @@ public class RClientCodegen extends DefaultCodegen implements CodegenConfig {
             sanitizedOperationId = "call_" + sanitizedOperationId;
         }
 
-        return camelize(sanitizedOperationId);
+        return underscore(sanitizedOperationId);
     }
 
     @Override


### PR DESCRIPTION
OpenApiTools introduced a breaking change wrt to capitalization of operationIds.  This is to prevent that change from affecting our codebase, yet keeping up to date with latest openapi-client-generation.